### PR TITLE
Bump ansible version minimum requirement to be 2.3 so that we get to …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ python:
 sudo: false
 
 env:
-  - ANSIBLE_VERSION=1.9.4
-  - ANSIBLE_VERSION=2.2.0.0
+  - ANSIBLE_VERSION=2.3.1.0
 
 install:
   # Install ansible

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This role mimics the ability in the AWS console to copy an existing launch confi
 Requirements
 ------------
 
-* Ansible 1.9+
-* awscli
+* Ansible 2.3+
 * boto3
 
 Role Variables
@@ -31,8 +30,8 @@ Role Variables
 Dependencies
 ------------
 
-The ec2_asg_facts Ansible extras module is handy to get the ASG group name and launch config name if you want to operate on a set
-of ASGs at once.
+None
+
 
 Example Playbook
 ----------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,31 @@
 ---
 # tasks file for ec2_lc_copy
-- name: Get details of a launch configuration by name
-  command: >
-    aws autoscaling describe-launch-configurations
-    --launch-configuration-names {{ ec2_lc_copy_lc_name }}
-    --profile {{ ec2_lc_copy_boto_profile | d(omit) }}
-    --region {{ ec2_lc_copy_region | d(omit) }}
-    --max-items 1
-  register: ec2_lc_copy_lc_stdout
 
-- name: Convert output to JSON and store it in a variable
-  set_fact: ec2_lc_copy_lc_current="{{ (ec2_lc_copy_lc_stdout.stdout | from_yaml).LaunchConfigurations[0] }}"
+- name: Get details of a launch configuration by name
+  ec2_lc_facts:
+    name: "{{ ec2_lc_copy_lc_name }}"
+    region: "{{ ec2_lc_copy_region | d(omit) }}"
+    profile: "{{ ec2_lc_copy_boto_profile | d(omit) }}"
+  register: ec2_lc_copy_lc_results
+
+- name: Fail if there are no matching launch configurations
+  fail:
+    msg: "No launch configurations matched on the name \"{{ ec2_lc_copy_lc_name }}\""
+  when: not ec2_lc_copy_lc_results.launch_configurations
+
+- name: Grab first (and only) result in list
+  set_fact: ec2_lc_copy_lc_current="{{ ec2_lc_copy_lc_results.launch_configurations[0] }}"
 
 - name: Create a new launch configuration based on the existing one with updated values
   ec2_lc:
     state: present
-    name: "{{ ec2_lc_copy_lc_current.LaunchConfigurationName }}-Copy"
-    image_id: "{{ ec2_lc_copy_image_id | d(ec2_lc_copy_lc_current.ImageId) }}"
-    instance_profile_name: "{{ ec2_lc_copy_instance_profile | d(ec2_lc_copy_lc_current.IamInstanceProfile) }}"
-    instance_type: "{{ ec2_lc_copy_instance_type | d(ec2_lc_copy_lc_current.InstanceType) }}"
-    key_name: "{{ ec2_lc_copy_key_name | default(ec2_lc_copy_lc_current.KeyName) }}"
-    security_groups: "{{ ec2_lc_copy_security_groups | d(ec2_lc_copy_lc_current.SecurityGroups) }}"
-    user_data: "{{ ec2_lc_copy_user_data | d(ec2_lc_copy_lc_current.UserData | b64decode) }}"
+    name: "{{ ec2_lc_copy_lc_current.launch_configuration_name }}-Copy"
+    image_id: "{{ ec2_lc_copy_image_id | d(ec2_lc_copy_lc_current.image_id) }}"
+    instance_profile_name: "{{ ec2_lc_copy_instance_profile | d(ec2_lc_copy_lc_current.iam_instance_profile) }}"
+    instance_type: "{{ ec2_lc_copy_instance_type | d(ec2_lc_copy_lc_current.instance_type) }}"
+    key_name: "{{ ec2_lc_copy_key_name | default(ec2_lc_copy_lc_current.key_name) }}"
+    security_groups: "{{ ec2_lc_copy_security_groups | d(ec2_lc_copy_lc_current.security_groups) }}"
+    user_data: "{{ ec2_lc_copy_user_data | d(ec2_lc_copy_lc_current.user_data | b64decode) }}"
     region: "{{ ec2_lc_copy_region | d(omit) }}"
     profile: "{{ ec2_lc_copy_boto_profile | d(omit) }}"
   register: ec2_lc_copy_lc_new


### PR DESCRIPTION
…use the ec2_lc_facts module instead of using the awscli directly.  Bump up travis.yml to test against the latest ansible 2.3.

@cmurtaugh 